### PR TITLE
[오강산] #8 필터링 기능 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@chakra-ui/react": "^2.5.1",
     "@emotion/react": "^11.10.6",
     "@emotion/styled": "^11.10.6",
+    "@tanstack/react-query": "^4.26.1",
     "@types/node": "18.14.6",
     "@types/react": "18.0.28",
     "@types/react-dom": "18.0.11",

--- a/src/components/ProductContext.tsx
+++ b/src/components/ProductContext.tsx
@@ -1,0 +1,66 @@
+import { fetchGetProduct, Product } from "@/services/product";
+import { useQuery } from "@tanstack/react-query";
+import {
+  createContext,
+  Dispatch,
+  ReactNode,
+  SetStateAction,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
+
+type ProductContextProps = {
+  products: Product[];
+  setProducts: Dispatch<SetStateAction<Product[]>>;
+  handleFilter: ({
+    locations,
+    minPrice,
+    maxPrice,
+  }: {
+    locations: string[];
+    minPrice: number;
+    maxPrice: number;
+  }) => void;
+};
+
+const ProductContext = createContext<ProductContextProps>(null!);
+
+export function ProductProvider({ children }: { children: ReactNode }) {
+  const { data } = useQuery(["products"], fetchGetProduct, {
+    select: ({ data }) => data,
+  });
+
+  const [products, setProducts] = useState<Product[]>([]);
+
+  const handleFilter: ProductContextProps["handleFilter"] = ({
+    locations,
+    minPrice,
+    maxPrice,
+  }) => {
+    if (!data) throw new Error("no data");
+    setProducts(
+      data.filter(
+        ({ spaceCategory, price }) =>
+          price > minPrice &&
+          price < maxPrice &&
+          (locations.length === 0 || locations.includes(spaceCategory))
+      )
+    );
+  };
+
+  useEffect(() => {
+    if (data) setProducts(data);
+  }, [data]);
+
+  return (
+    <ProductContext.Provider value={{ products, setProducts, handleFilter }}>
+      {children}
+    </ProductContext.Provider>
+  );
+}
+
+export function useProduct() {
+  if (!ProductContext) throw new Error("No Product Context");
+  return useContext(ProductContext);
+}

--- a/src/components/ProductContext.tsx
+++ b/src/components/ProductContext.tsx
@@ -39,8 +39,8 @@ export function ProductProvider({ children }: { children: ReactNode }) {
     setProducts(
       productOrigin.filter(
         ({ spaceCategory, price }) =>
-          price > minPrice &&
-          price < maxPrice &&
+          price >= minPrice &&
+          price <= maxPrice &&
           (locations.length === 0 || locations.includes(spaceCategory))
       )
     );

--- a/src/components/ProductContext.tsx
+++ b/src/components/ProductContext.tsx
@@ -2,9 +2,7 @@ import { fetchGetProduct, Product } from "@/services/product";
 import { useQuery } from "@tanstack/react-query";
 import {
   createContext,
-  Dispatch,
   ReactNode,
-  SetStateAction,
   useContext,
   useEffect,
   useState,
@@ -12,7 +10,6 @@ import {
 
 type ProductContextProps = {
   products: Product[];
-  setProducts: Dispatch<SetStateAction<Product[]>>;
   handleFilter: ({
     locations,
     minPrice,
@@ -27,7 +24,7 @@ type ProductContextProps = {
 const ProductContext = createContext<ProductContextProps>(null!);
 
 export function ProductProvider({ children }: { children: ReactNode }) {
-  const { data } = useQuery(["products"], fetchGetProduct, {
+  const { data: productOrigin } = useQuery(["products"], fetchGetProduct, {
     select: ({ data }) => data,
   });
 
@@ -38,9 +35,9 @@ export function ProductProvider({ children }: { children: ReactNode }) {
     minPrice,
     maxPrice,
   }) => {
-    if (!data) throw new Error("no data");
+    if (!productOrigin) throw new Error("no data");
     setProducts(
-      data.filter(
+      productOrigin.filter(
         ({ spaceCategory, price }) =>
           price > minPrice &&
           price < maxPrice &&
@@ -50,11 +47,11 @@ export function ProductProvider({ children }: { children: ReactNode }) {
   };
 
   useEffect(() => {
-    if (data) setProducts(data);
-  }, [data]);
+    if (productOrigin) setProducts(productOrigin);
+  }, [productOrigin]);
 
   return (
-    <ProductContext.Provider value={{ products, setProducts, handleFilter }}>
+    <ProductContext.Provider value={{ products, handleFilter }}>
       {children}
     </ProductContext.Provider>
   );

--- a/src/components/ProductFilter.tsx
+++ b/src/components/ProductFilter.tsx
@@ -1,19 +1,39 @@
 import {
+  Badge,
+  Box,
   Button,
+  Drawer,
+  DrawerBody,
+  DrawerCloseButton,
+  DrawerContent,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerOverlay,
+  Flex,
+  Heading,
   RangeSlider,
   RangeSliderFilledTrack,
   RangeSliderThumb,
   RangeSliderTrack,
+  Stack,
+  Text,
+  useDisclosure,
 } from "@chakra-ui/react";
 import { useProduct } from "@/components/ProductContext";
 import { useState } from "react";
+import { SpaceCategories } from "@/services/product";
+import { css } from "@emotion/react";
 
 const PRICE_MAX = 999_999_999;
+const PRICE_CONVERT = (percent: number) => {
+  return percent * 1000;
+};
 
 export default function Filter() {
   const { handleFilter } = useProduct();
   const [locations, setLocations] = useState<string[]>([]);
-  const [priceRange, setPriceRange] = useState([0, PRICE_MAX]);
+  const [priceRange, setPriceRange] = useState([0, 100]);
+  const { isOpen, onOpen, onClose } = useDisclosure();
 
   const addLocation = (location: string) => {
     if (locations.includes(location)) {
@@ -23,40 +43,86 @@ export default function Filter() {
     }
   };
 
-  const convertPriceRange = ([min, max]: [number, number]) => {
-    setPriceRange([min * 2000, max === 100 ? PRICE_MAX : max * 2000]);
-  };
-
   return (
     <>
-      <RangeSlider
-        aria-label={["min", "max"]}
-        onChangeEnd={convertPriceRange}
-        step={5}
-      >
-        <RangeSliderTrack>
-          <RangeSliderFilledTrack />
-        </RangeSliderTrack>
-        <RangeSliderThumb index={0} />
-        <RangeSliderThumb index={1} />
-      </RangeSlider>
-      {locations.map((e, i) => (
-        <div key={i}>{e}</div>
-      ))}
-      <Button onClick={() => addLocation("서울")}>서울</Button>
-      <Button onClick={() => addLocation("강원")}>강원</Button>
-      <Button onClick={() => addLocation("부산")}>부산</Button>
-      <Button
-        onClick={() =>
-          handleFilter({
-            locations,
-            minPrice: priceRange[0],
-            maxPrice: priceRange[1],
-          })
-        }
-      >
-        gogo
-      </Button>
+      <Button onClick={onOpen}>필터</Button>
+      <Drawer isOpen={isOpen} placement="right" onClose={onClose}>
+        <DrawerOverlay />
+        <DrawerContent>
+          <DrawerCloseButton />
+          <DrawerHeader>필터</DrawerHeader>
+
+          <DrawerBody>
+            <Heading size="sm">가격</Heading>
+
+            <RangeSlider
+              aria-label={["min", "max"]}
+              onChangeEnd={setPriceRange}
+              defaultValue={priceRange}
+              step={5}
+            >
+              <RangeSliderTrack>
+                <RangeSliderFilledTrack />
+              </RangeSliderTrack>
+              <RangeSliderThumb index={0} />
+              <RangeSliderThumb index={1} />
+            </RangeSlider>
+            <Flex justifyContent={"space-between"}>
+              <Text fontSize={"xs"}>0원</Text>
+              <Text fontSize={"xs"} align="right">
+                {PRICE_CONVERT(100).toLocaleString("ko")}원
+                <br />
+                이상
+              </Text>
+            </Flex>
+            <Text fontSize={"sm"}>
+              최소 : {PRICE_CONVERT(priceRange[0]).toLocaleString("ko")}원
+            </Text>
+            <Text fontSize={"sm"}>
+              최대 : {PRICE_CONVERT(priceRange[1]).toLocaleString("ko")}원
+              {priceRange[1] === 100 ? " 이상" : null}
+            </Text>
+            <Heading size="sm" mt={5}>
+              지역
+            </Heading>
+            {SpaceCategories.map((e) => (
+              <Badge
+                key={e}
+                mr={2}
+                variant={locations.includes(e) ? "solid" : "outline"}
+                colorScheme={locations.includes(e) ? "blue" : "gray"}
+                onClick={() => addLocation(e)}
+                css={css`
+                  :hover {
+                    cursor: pointer;
+                  }
+                `}
+              >
+                {e}
+              </Badge>
+            ))}
+            <Flex mt={10} justifyContent="space-between">
+              <Button variant="outline" mr={3} onClick={onClose} w={"full"}>
+                취소
+              </Button>
+              <Button
+                colorScheme="blue"
+                w={"full"}
+                onClick={() => {
+                  handleFilter({
+                    locations,
+                    minPrice: PRICE_CONVERT(priceRange[0]),
+                    maxPrice: PRICE_CONVERT(priceRange[1]),
+                  });
+                  onClose();
+                }}
+              >
+                적용하기
+              </Button>
+            </Flex>
+          </DrawerBody>
+        </DrawerContent>
+      </Drawer>
     </>
   );
 }

--- a/src/components/ProductFilter.tsx
+++ b/src/components/ProductFilter.tsx
@@ -1,0 +1,62 @@
+import {
+  Button,
+  RangeSlider,
+  RangeSliderFilledTrack,
+  RangeSliderThumb,
+  RangeSliderTrack,
+} from "@chakra-ui/react";
+import { useProduct } from "@/components/ProductContext";
+import { useState } from "react";
+
+const PRICE_MAX = 999_999_999;
+
+export default function Filter() {
+  const { handleFilter } = useProduct();
+  const [locations, setLocations] = useState<string[]>([]);
+  const [priceRange, setPriceRange] = useState([0, PRICE_MAX]);
+
+  const addLocation = (location: string) => {
+    if (locations.includes(location)) {
+      setLocations(locations.filter((e) => e !== location));
+    } else {
+      setLocations([...locations, location]);
+    }
+  };
+
+  const convertPriceRange = ([min, max]: [number, number]) => {
+    setPriceRange([min * 2000, max === 100 ? PRICE_MAX : max * 2000]);
+  };
+
+  return (
+    <>
+      <RangeSlider
+        aria-label={["min", "max"]}
+        onChangeEnd={convertPriceRange}
+        step={5}
+      >
+        <RangeSliderTrack>
+          <RangeSliderFilledTrack />
+        </RangeSliderTrack>
+        <RangeSliderThumb index={0} />
+        <RangeSliderThumb index={1} />
+      </RangeSlider>
+      {locations.map((e, i) => (
+        <div key={i}>{e}</div>
+      ))}
+      <Button onClick={() => addLocation("서울")}>서울</Button>
+      <Button onClick={() => addLocation("강원")}>강원</Button>
+      <Button onClick={() => addLocation("부산")}>부산</Button>
+      <Button
+        onClick={() =>
+          handleFilter({
+            locations,
+            minPrice: priceRange[0],
+            maxPrice: priceRange[1],
+          })
+        }
+      >
+        gogo
+      </Button>
+    </>
+  );
+}

--- a/src/components/ProductList.tsx
+++ b/src/components/ProductList.tsx
@@ -1,11 +1,12 @@
 /** @jsxImportSource @emotion/react */
-import { Product } from "@/services/product";
+import { useProduct } from "@/components/ProductContext";
 import { SimpleGrid } from "@chakra-ui/react";
 import { css } from "@emotion/react";
 import { Fragment } from "react";
 import ProductItem from "./ProductItem";
 
-export default function ProductList({ products }: { products: Product[] }) {
+export default function ProductList() {
+  const { products } = useProduct();
   return (
     <>
       <SimpleGrid

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,10 +1,22 @@
 import type { AppProps } from "next/app";
 import { ChakraProvider } from "@chakra-ui/react";
+import {
+  QueryClientProvider,
+  QueryClient,
+  Hydrate,
+} from "@tanstack/react-query";
+import { useState } from "react";
 
 export default function App({ Component, pageProps }: AppProps) {
+  const [queryClient] = useState(() => new QueryClient());
+
   return (
     <ChakraProvider>
-      <Component {...pageProps} />
+      <QueryClientProvider client={queryClient}>
+        <Hydrate state={pageProps.dehydratedState}>
+          <Component {...pageProps} />
+        </Hydrate>
+      </QueryClientProvider>
     </ChakraProvider>
   );
 }

--- a/src/pages/api/product.ts
+++ b/src/pages/api/product.ts
@@ -1,0 +1,88 @@
+import { NextApiRequest, NextApiResponse } from "next";
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === "GET") res.status(200).json(mock_data);
+}
+
+const mock_data = [
+  {
+    idx: 1,
+    name: "가나다 목장 하루 이용권",
+    mainImage: "https://picsum.photos/id/17/300/300",
+    description: "가나다 목장 하루 이용권에 대한 내용입니다.",
+    spaceCategory: "강원",
+    price: 30000,
+    maximumPurchases: 5,
+    registrationDate: "2023.01.01 15:07:00",
+  },
+  {
+    idx: 2,
+    name: "AA 아쿠아리움 상어 밥주기 이용권",
+    mainImage: "https://picsum.photos/id/18/300/300",
+    description: "AA 아쿠아리움 상어 밥주기에 대한 내용입니다.",
+    spaceCategory: "서울",
+    price: 10000,
+    maximumPurchases: 2,
+    registrationDate: "2023.01.02 11:07:00",
+  },
+  {
+    idx: 3,
+    name: "라멘 만들기 체험권",
+    mainImage: "https://picsum.photos/id/19/300/300",
+    description: "라멘 만들기 체험권에 대한 내용입니다.",
+    spaceCategory: "서울",
+    price: 15000,
+    maximumPurchases: 5,
+    registrationDate: "2023.01.03 15:07:00",
+  },
+  {
+    idx: 4,
+    name: "씽씽카 렌달 이용권",
+    mainImage: "https://picsum.photos/id/20/300/300",
+    description: "씽씽카 렌탈 이용권에 대한 내용입니다.",
+    spaceCategory: "부산",
+    price: 1000,
+    maximumPurchases: 5,
+    registrationDate: "2023.01.03 17:37:00",
+  },
+  {
+    idx: 5,
+    name: "AA 전망대 당일 입장권",
+    mainImage: "https://picsum.photos/id/25/300/300",
+    description: "전망대 당일 입장권에 대한 내용입니다.",
+    spaceCategory: "대구",
+    price: 15000,
+    maximumPurchases: 5,
+    registrationDate: "2023.01.03 15:42:00",
+  },
+  {
+    idx: 6,
+    name: "산에서 시작하는 원데이 캠핑 1박 이용권",
+    mainImage: "https://picsum.photos/id/28/300/300",
+    description: "산에서 시작하는 원데이 캠핑 1박 이용권에 대한 내용입니다.",
+    spaceCategory: "강원",
+    price: 15000,
+    maximumPurchases: 5,
+    registrationDate: "2023.01.04 17:00:00",
+  },
+  {
+    idx: 7,
+    name: "ABC 페러글라이딩 이벤트 참여권",
+    mainImage: "https://picsum.photos/id/27/300/300",
+    description: "ABC 페러글라이딩 이벤트 참여권에 대한 내용입니다.",
+    spaceCategory: "서울",
+    price: 25000,
+    maximumPurchases: 2,
+    registrationDate: "2023.01.05 14:07:00",
+  },
+  {
+    idx: 8,
+    name: "ABC 항공 제주 특가 이벤트",
+    mainImage: "https://picsum.photos/id/38/300/300",
+    description: "ABC 항공 제주 특가 이벤트에 대한 내용입니다.",
+    spaceCategory: "제주",
+    price: 10000,
+    maximumPurchases: 3,
+    registrationDate: "2023.01.07 18:00:00",
+  },
+];

--- a/src/pages/main.tsx
+++ b/src/pages/main.tsx
@@ -1,12 +1,15 @@
 /** @jsxImportSource @emotion/react */
 import Head from "next/head";
-import { fetchGetProduct, Product } from "../services/product";
-import { GetServerSideProps } from "next";
 import Link from "next/link";
 import ProductList from "@/components/ProductList";
 import { css } from "@emotion/react";
+import Filter from "@/components/ProductFilter";
+import { GetStaticProps } from "next";
+import { fetchGetProduct } from "@/services/product";
+import { dehydrate, QueryClient } from "@tanstack/react-query";
+import { ProductProvider } from "@/components/ProductContext";
 
-export default function MainPage({ products }: { products: Product[] }) {
+export default function MainPage() {
   return (
     <>
       <Head>
@@ -31,18 +34,24 @@ export default function MainPage({ products }: { products: Product[] }) {
           `}
         >
           <Link href={"reservations"}>장바구니</Link>
-          <ProductList products={products} />
+          <ProductProvider>
+            <Filter />
+            <ProductList />
+          </ProductProvider>
         </div>
       </main>
     </>
   );
 }
-export const getServerSideProps: GetServerSideProps = async (context) => {
-  const { data: products } = await fetchGetProduct();
+
+export const getStaticProps: GetStaticProps = async (context) => {
+  const queryClient = new QueryClient();
+
+  await queryClient.prefetchQuery(["products"], fetchGetProduct);
 
   return {
     props: {
-      products,
+      dehydratedState: dehydrate(queryClient),
     },
   };
 };

--- a/src/services/product.ts
+++ b/src/services/product.ts
@@ -1,9 +1,7 @@
 import axios from "axios";
 
 export const fetchGetProduct = async () => {
-  return axios.get<GetProductResponse>(
-    "https://s3.us-west-2.amazonaws.com/secure.notion-static.com/f1be87a4-38e1-4c1e-a527-bd4775812374/mock_data.json?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=AKIAT73L2G45EIPT3X45%2F20230307%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20230307T170051Z&X-Amz-Expires=86400&X-Amz-Signature=4aed64020491e66497229cb698a732a66fba089cdcf071a2e397bb13a98366c8&X-Amz-SignedHeaders=host&response-content-disposition=filename%3D%22mock_data.json%22&x-id=GetObject"
-  );
+  return axios.get<GetProductResponse>("/api/product");
 };
 
 export type Product = {

--- a/src/services/product.ts
+++ b/src/services/product.ts
@@ -4,15 +4,25 @@ export const fetchGetProduct = async () => {
   return axios.get<GetProductResponse>("/api/product");
 };
 
+export type GetProductResponse = Product[];
+
 export type Product = {
   idx: number;
   name: string;
   mainImage: string;
   description: string;
-  spaceCategory: string;
+  spaceCategory: SpaceCategory;
   price: number;
   maximumPurchases: number;
   registrationDate: Date;
 };
 
-export type GetProductResponse = Product[];
+export const SpaceCategories = [
+  "강원",
+  "서울",
+  "부산",
+  "대구",
+  "제주",
+] as const;
+
+export type SpaceCategory = typeof SpaceCategories[number];

--- a/yarn.lock
+++ b/yarn.lock
@@ -1125,6 +1125,19 @@
   dependencies:
     tslib "^2.4.0"
 
+"@tanstack/query-core@4.26.1":
+  version "4.26.1"
+  resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-4.26.1.tgz#7a441086c4d3d79e1d156c0a355bd3567213626e"
+  integrity sha512-Zrx2pVQUP4ndnsu6+K/m8zerXSVY8QM+YSbxA1/jbBY21GeCd5oKfYl92oXPK0hPEUtoNuunIdiq0ZMqLos+Zg==
+
+"@tanstack/react-query@^4.26.1":
+  version "4.26.1"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-4.26.1.tgz#d254f6b7b297b5ae4204c84e6622506e5ec77d09"
+  integrity sha512-i3dnz4TOARGIXrXQ5P7S25Zfi4noii/bxhcwPurh2nrf5EUCcAt/95TB2HSmMweUBx206yIMWUMEQ7ptd6zwDg==
+  dependencies:
+    "@tanstack/query-core" "4.26.1"
+    use-sync-external-store "^1.2.0"
+
 "@types/json5@^0.0.29":
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
@@ -3313,6 +3326,11 @@ use-sidecar@^1.1.2:
   dependencies:
     detect-node-es "^1.1.0"
     tslib "^2.0.0"
+
+use-sync-external-store@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz#7dbefd6ef3fe4e767a0cf5d7287aacfb5846928a"
+  integrity sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==
 
 which-boxed-primitive@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
## 개요
- 여행 상품 리스트의 가격(price), 공간(spaceCategory) 필터 기능 구현
- api로 받은 물품과 필터링된 물품 상태 관리 고민

## TODO
2. 여행 상품 리스트의 가격(price), 공간(spaceCategory) 필터 기능을 만들어주세요.
 - [x] 개별 필터링
 - [x] 다중 필터링

## 작업사항
### 필터 기능 구현
- 필터 옵션을 set하는 함수와 필터 옵션 상태를 context API로 관리

## 기타
### 서버에 있는 상품 정보와 사용자가 필터링한 상품 정보 상태 관리 고민
- getStaticProps로 페이지가 요청될 때 서버에서 상품 정보를 얻는 api를 호출, 상품 정보를 html에 넣을 수 있어서 SEO에 유리
- 하지만 예약 사이트 특성상 실시간성이 중요하다고 판단해 첫 페이지 랜더링 이후 상품 정보를 항상 유효한 정보로 유지하기 위해 react-query를 사용
- react-query는 훅이나 컴포넌트 안에서만 사용 가능해 getStaticProps 사용에 문제 발생
  - prefetch 기능을 사용했지만 실제로 build된 html 파일에는 데이터가 들어있지 않은 것으로 확인
  - 개별 데이터가 주는 SEO 향상보다 실시간성이 중요하다고 생각해 react-query는 일단 두고 getStaticProps에서 활용할 수 있는 방법 찾아 보는 중
